### PR TITLE
Only consider empty? for hashes and arrays in _blank?

### DIFF
--- a/lib/easy_diff/core.rb
+++ b/lib/easy_diff/core.rb
@@ -68,7 +68,7 @@ module EasyDiff
     end
 
     def self._blank?(obj)
-      if obj.respond_to?(:empty?)
+      if obj.is_a?(Hash) || obj.is_a?(Array)
         obj.empty?
       else
         obj.nil?


### PR DESCRIPTION
This is broken at least for strings: I had the case where a string moved
from "foo" to "", and it got marked as removed.
