### PR TITLE
fix merging of Arrays of Hashes

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -54,7 +54,8 @@ The first contains what has to be removed from self to create the second hash. T
 
 === Hash#easy_merge
 
-Takes a hash and recursively merges it with self. Arrays are merged by the union operation and then sorted.
+Takes a hash and recursively merges it with self. Arrays are merged by the union operation and then sorted. Arrays of Hashes are sorted by invoking +#sort+ on each Hash to make them comparable.
+
 Using Hash#easy_merge! will modify self instead of returning a new hash.
 
   original = {

--- a/lib/easy_diff/core.rb
+++ b/lib/easy_diff/core.rb
@@ -56,7 +56,9 @@ module EasyDiff
         added_keys.each{ |key| original[key] = easy_merge!(original[key], added[key])}
       elsif original.is_a?(Array) && added.is_a?(Array)
         original |=  added
-        original.sort!
+        original.sort_by! { |item|
+          item.is_a?(Hash) ? item.sort : item
+        }
       else
         original = added.safe_dup
       end

--- a/spec/easy_diff_spec.rb
+++ b/spec/easy_diff_spec.rb
@@ -131,4 +131,30 @@ describe EasyDiff do
     removed.should == {:possibly_empty_string => ""}
     added.should == {:possibly_empty_string => "not empty"}
   end
+
+  it "should merge Arrays containing Hashes" do
+    original = {
+      "key" => [
+        {"c" => "1"},
+        {"a" => "2"},
+        {"a" => "1"},
+      ]
+    }
+
+    to_merge = {
+      "key" => [
+        {"b" => "2"},
+      ]
+    }
+
+    merged = original.easy_merge to_merge
+    merged.should == {
+      "key" => [
+        {"a" => "1"},
+        {"a" => "2"},
+        {"b" => "2"},
+        {"c" => "1"},
+      ]
+    }
+  end
 end


### PR DESCRIPTION
Merging Arrays relies on being able to sort them, but by default Hashes are not comparable, so merging of Arrays of Hashes failed with:

  comparison of Hash with Hash failed (ArgumentError)

Invoking `Hash#sort` on each Hash makes it comparable in a way which seems reasonable for sorting by.