### PR TITLE
Unmerge Arrays containing Hashes as well

### DIFF
--- a/lib/easy_diff/core.rb
+++ b/lib/easy_diff/core.rb
@@ -41,7 +41,9 @@ module EasyDiff
         keys_in_common.each{ |key| original.delete(key) if easy_unmerge!(original[key], removed[key]).nil? }
       elsif original.is_a?(Array) && removed.is_a?(Array)
         original.reject!{ |e| removed.include?(e) }
-        original.sort!
+        original.sort_by! { |item|
+          item.is_a?(Hash) ? item.sort : item
+        }
       elsif original == removed
         original = nil
       end

--- a/spec/easy_diff_spec.rb
+++ b/spec/easy_diff_spec.rb
@@ -132,29 +132,49 @@ describe EasyDiff do
     added.should == {:possibly_empty_string => "not empty"}
   end
 
-  it "should merge Arrays containing Hashes" do
-    original = {
-      "key" => [
-        {"c" => "1"},
-        {"a" => "2"},
-        {"a" => "1"},
-      ]
-    }
+  describe 'handling Arrays containing Hashes' do
+    let(:original) do
+      {
+        "key" => [
+          {"c" => "1"},
+          {"a" => "2"},
+          {"a" => "1"},
+        ]
+      }
+    end
 
-    to_merge = {
-      "key" => [
-        {"b" => "2"},
-      ]
-    }
+    it "should merge properly" do
+      to_merge = {
+        "key" => [
+          {"b" => "2"},
+        ]
+      }
 
-    merged = original.easy_merge to_merge
-    merged.should == {
-      "key" => [
-        {"a" => "1"},
-        {"a" => "2"},
-        {"b" => "2"},
-        {"c" => "1"},
-      ]
-    }
+      merged = original.easy_merge to_merge
+      merged.should == {
+        "key" => [
+          {"a" => "1"},
+          {"a" => "2"},
+          {"b" => "2"},
+          {"c" => "1"},
+        ]
+      }
+    end
+
+    it "should unmerge properly" do
+      to_unmerge = {
+        "key" => [
+          {"a" => "2"},
+        ]
+      }
+
+      unmerged = original.easy_unmerge to_unmerge
+      unmerged.should == {
+        "key" => [
+          {"a" => "1"},
+          {"c" => "1"},
+        ]
+      }
+    end
   end
 end


### PR DESCRIPTION
@Blargel, `#easy_unmerge` fails with the same error as that in https://github.com/Blargel/easy_diff/pull/5. Implemented comparable fix here.