### PR TITLE
Allow merging and unmerging to succeed even if sorting fails

### DIFF
--- a/lib/easy_diff/core.rb
+++ b/lib/easy_diff/core.rb
@@ -41,9 +41,12 @@ module EasyDiff
         keys_in_common.each{ |key| original.delete(key) if easy_unmerge!(original[key], removed[key]).nil? }
       elsif original.is_a?(Array) && removed.is_a?(Array)
         original.reject!{ |e| removed.include?(e) }
-        original.sort_by! { |item|
-          item.is_a?(Hash) ? item.sort : item
-        }
+        begin
+          original.sort_by! { |item|
+            item.is_a?(Hash) ? item.sort : item
+          }
+        rescue
+        end
       elsif original == removed
         original = nil
       end
@@ -58,9 +61,12 @@ module EasyDiff
         added_keys.each{ |key| original[key] = easy_merge!(original[key], added[key])}
       elsif original.is_a?(Array) && added.is_a?(Array)
         original |=  added
-        original.sort_by! { |item|
-          item.is_a?(Hash) ? item.sort : item
-        }
+        begin
+          original.sort_by! { |item|
+            item.is_a?(Hash) ? item.sort : item
+          }
+        rescue
+        end
       else
         original = added.safe_dup
       end

--- a/spec/easy_diff_spec.rb
+++ b/spec/easy_diff_spec.rb
@@ -177,4 +177,41 @@ describe EasyDiff do
       }
     end
   end
+
+  describe 'handling Arrays containing Hashes with nils' do
+    let(:original) do
+      {
+        "key" => [
+          { "a" => "1", "b" => "2" },
+          { "a" => nil, "c" => "2" },
+          { "e" => "5" },
+        ]
+      }
+    end
+
+    it "should merge without errors" do
+      to_merge = {
+        "key" => [
+          { "d" => "4" },
+        ]
+      }
+      expect { original.easy_merge(to_merge) }.to_not raise_error
+    end
+
+    it "should unmerge without errors" do
+      to_unmerge = {
+        "key" => [
+          { "e" => "5" },
+        ]
+      }
+
+      unmerged = original.easy_unmerge to_unmerge
+      unmerged.should == {
+        "key" => [
+          { "a" => "1", "b" => "2" },
+          { "a" => nil, "c" => "2" },
+        ]
+      }
+    end
+  end
 end


### PR DESCRIPTION
@Blargel, sorting can fail in some cases, see example in spec. Thought here is to allow merge to work but leave it unsorted.
